### PR TITLE
chore: replace slatify by notify-on-failure

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
       - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        uses: digitalservicebund/notify-on-failure-gha@0b21f14f28717b3b756282824976cdd1354b1235 # v1.3.0
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -59,7 +59,7 @@ jobs:
       - name: Run license scanner
         run: ./gradlew checkLicense
       - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        uses: digitalservicebund/notify-on-failure-gha@0b21f14f28717b3b756282824976cdd1354b1235 # v1.3.0
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -113,7 +113,7 @@ jobs:
           path: "vuln.json"
           if-no-files-found: error
       - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        uses: digitalservicebund/notify-on-failure-gha@0b21f14f28717b3b756282824976cdd1354b1235 # v1.3.0
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -153,7 +153,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        uses: digitalservicebund/notify-on-failure-gha@0b21f14f28717b3b756282824976cdd1354b1235 # v1.3.0
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -212,7 +212,7 @@ jobs:
       - id: set-version
         run: echo "version=$CONTAINER_IMAGE_VERSION" >> $GITHUB_OUTPUT
       - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        uses: digitalservicebund/notify-on-failure-gha@0b21f14f28717b3b756282824976cdd1354b1235 # v1.3.0
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,20 +39,10 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65
-        if: ${{ failure() && github.ref == 'refs/heads/main' && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
-          type: ${{ job.status }}
-          job_name: "Build :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   audit-licenses:
     runs-on: ubuntu-latest
@@ -69,20 +59,10 @@ jobs:
       - name: Run license scanner
         run: ./gradlew checkLicense
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65
-        if: ${{ failure() && github.ref == 'refs/heads/main' && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
-          type: ${{ job.status }}
-          job_name: "License audit :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   vulnerability-scan:
     runs-on: ubuntu-latest
@@ -133,20 +113,10 @@ jobs:
           path: "vuln.json"
           if-no-files-found: error
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65
-        if: ${{ failure() && github.ref == 'refs/heads/main' && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
-          type: ${{ job.status }}
-          job_name: "Vulnerability scan :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   analyze:
     runs-on: ubuntu-latest
@@ -183,20 +153,10 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
-          type: ${{ job.status }}
-          job_name: "Analyze :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build-and-push-image:
     runs-on: ubuntu-latest
@@ -252,17 +212,7 @@ jobs:
       - id: set-version
         run: echo "version=$CONTAINER_IMAGE_VERSION" >> $GITHUB_OUTPUT
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
-          type: ${{ job.status }}
-          job_name: "Build/push image :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
       - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        uses: digitalservicebund/notify-on-failure-gha@0b21f14f28717b3b756282824976cdd1354b1235 # v1.3.0
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -76,17 +76,7 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65
-        if: ${{ failure() && github.ref == 'refs/heads/main' && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
-          type: ${{ job.status }}
-          job_name: "Vulnerability scan :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -16,7 +16,7 @@ jobs:
         # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
         uses: carhartl/talisman-secrets-scan-action@702fc5c52170632a568124896148a80f38521ac4
       - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        uses: digitalservicebund/notify-on-failure-gha@0b21f14f28717b3b756282824976cdd1354b1235 # v1.3.0
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -16,17 +16,7 @@ jobs:
         # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
         uses: carhartl/talisman-secrets-scan-action@702fc5c52170632a568124896148a80f38521ac4
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         with:
-          type: ${{ job.status }}
-          job_name: "Secrets scan :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Since [slatify](https://github.com/lazy-actions/slatify/) isn't maintained anymore, we're replacing it [notify-on-failure](https://github.com/digitalservicebund/notify-on-failure-gha).
All you have to do is review this PR, merge it, and let Platform know if you run into any issue.

More details [available here](https://platform-docs.prod.ds4g.net/user-docs/how-to-guides/ci-cd/slack-integration).