### PR TITLE
chore(deps): bump netty-common from 4.1.114 to 4.1.115

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.spring.boot.starter.security)
     implementation(libs.spring.boot.starter.webflux)
+    implementation(libs.netty.common)
 
     compileOnly(libs.lombok)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ spring-boot = "3.3.5"
 archunit-junit5 = "com.tngtech.archunit:archunit-junit5:1.3.0"
 lombok = { module = "org.projectlombok:lombok" }
 mockito-junit-jupiter = "org.mockito:mockito-junit-jupiter:5.14.2"
+netty-common = "io.netty:netty-common:4.1.115.Final"
 reactor-test = { module = "io.projectreactor:reactor-test" }
 spring-boot-devtools = { module = "org.springframework.boot:spring-boot-devtools" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }


### PR DESCRIPTION
pinned the version of netty-common, in order to fix CVE-2024-47535.

Refs: https://github.com/digitalservicebund/java-application-template/security/code-scanning/178