### PR TITLE
Potential fix for code scanning alert no. 205: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -1,4 +1,6 @@
 name: Secrets Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/java-application-template/security/code-scanning/205](https://github.com/digitalservicebund/java-application-template/security/code-scanning/205)

To address the issue, a `permissions` block specifying only the required permissions should be added to the workflow. The minimal safe setting is `contents: read`, which allows jobs to read repository contents (source code, etc.)—sufficient for running scans and notifications but prevents any write access. This will be placed either at the root level (to affect all jobs) or within the specific job, but root-level placement is preferred for a single-job workflow for clarity. No existing functionality will be affected, and there is no need to add any imports, since this is a YAML workflow file.

**Required changes:**
- Add:
  ```yaml
  permissions:
    contents: read
  ```
- To be placed after the workflow `name`, before `on:` (i.e., at the top/root of `.github/workflows/secrets-check.yml`).
- No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
