### PR TITLE
Potential fix for code scanning alert no. 207: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/java-application-template/security/code-scanning/207](https://github.com/digitalservicebund/java-application-template/security/code-scanning/207)

To fix this issue, we should add an explicit `permissions` block to the `audit-licenses` job since this is the job highlighted by CodeQL for lacking permissions, and (recommended) set a workflow root-level `permissions` block covering all jobs as a minimal default. Since the only privileged step relevant in this workflow is uploading SARIF files (which already requests extra permissions in its own job), the minimal required permission for these jobs is `contents: read`. This fix will involve editing the `.github/workflows/pipeline.yml` file to add `permissions: contents: read` at the top level, just after the `name:` and before `on:`. This ensures all jobs, unless overridden, will inherit the least privilege necessary. If repository needs change, individual jobs can override permissions as already demonstrated in `vulnerability-scan`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
