### PR TITLE
Potential fix for code scanning alert no. 206: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/java-application-template/security/code-scanning/206](https://github.com/digitalservicebund/java-application-template/security/code-scanning/206)

To fix this issue, add a `permissions` block at the workflow root (top-level, just after `name:` or `on:`), which will restrict the GITHUB_TOKEN to minimal access unless overridden by individual jobs. For this workflow, the safest starting point is to set `contents: read` at the workflow root, as recommended. The `vulnerability-scan` job already specifies expanded permissions it needs (`security-events: write`), so it will override the root permissions for itself.

**Steps:**
- Add the following block at the root of `.github/workflows/pipeline.yml` (after the `name:` and before `env:` or `jobs:`):

```yaml
permissions:
  contents: read
```

- No other changes are required since individual jobs can override this as needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
